### PR TITLE
Remove redirect parameter to prevent losing widgetHost value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import styles from './styles.css'
 
 function ImagekitMediaLibraryWidget() {
   var IK_HOST = 'https://eml.imagekit.io';
-  var IK_SRC = `${IK_HOST}/media-library-widget?redirectTo=media-library-widget&isMediaLibraryWidget=true`;
+  var IK_SRC = `${IK_HOST}/media-library-widget?isMediaLibraryWidget=true`;
   var IK_FRAME_TITLE = 'ImageKit Embedded Media Library';
   var callbackFunction;
   var view = "modal";


### PR DESCRIPTION
The redirect causes the widgetHost parameter to be dropped and therefor the postMessage function fails due to no origin being available.

Dropping the redirect fixes it because it will correctly set the widgetHost value.