### PR TITLE
fix: added open and destroy functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.1.0
+
+- fix: Added allow-downloads permission to iframe sandbox attributes
+- feat: Added open() and destroy() functions for better widget lifecycle management
+- improvement: Improved event listener management and memory cleanup
+
+# 2.0.0
+
+- Introduced 'mlSettings' parameter in plugin options
+- Added Typescript support
+
 # 1.0.4
 
 - Fix: Allow popups for google login

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imagekit-media-library-widget",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imagekit-media-library-widget",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagekit-media-library-widget",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Javascript plugin for using Imagekit Media Library Widget",
   "main": "dist/imagekit-media-library-widget.cjs.js",
   "module": "dist/imagekit-media-library-widget.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export class ImagekitMediaLibraryWidget {
         mainFrame = document.createElement("iframe");
         mainFrame.title = this.IK_FRAME_TITLE;
         mainFrame.src = this.generateInitialUrl();
-        mainFrame.setAttribute('sandbox', 'allow-top-navigation allow-same-origin allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox');
+        mainFrame.setAttribute('sandbox', 'allow-top-navigation allow-same-origin allow-scripts allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-downloads');
         mainFrame.height = this.options?.dimensions?.height || "100%";
         mainFrame.width = this.options?.dimensions?.width || "100%";
         mainFrame.style.border = this.options.style.border;


### PR DESCRIPTION
This pull request includes several improvements and new features to the `imagekit-media-library-widget` project. The most important changes include adding new functions for better widget lifecycle management, improving event listener management and memory cleanup, and updating the iframe sandbox attributes.

New features and improvements:

* Added `open()` and `destroy()` functions to the `ImagekitMediaLibraryWidget` class for better widget lifecycle management. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R201-R239) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L171)
* Improved event listener management by initializing event handlers for later removal and updating the `setListeners` method. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R55-R80) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L130-R151) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L171)
* Improved memory cleanup by removing event listeners and DOM elements in the `destroy` method.

Bug fixes:

* Added `allow-downloads` permission to iframe sandbox attributes to fix download issues.

Documentation updates:

* Updated `CHANGELOG.md` to reflect the new version 2.0.1 and the changes included in this release.
* Updated `package.json` to reflect the new version 2.1.0.